### PR TITLE
Updates to support Mobilecoin Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20211006
+FROM ubuntu:focal-20220113
 
 RUN  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime\
   && apt-get update \
@@ -12,6 +12,7 @@ RUN  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime\
      jq \
      libclang-dev \
      libprotobuf-dev \
+     libpq-dev \
      libssl1.1 \
      libssl-dev \
      llvm \
@@ -24,21 +25,22 @@ RUN  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime\
 SHELL ["/bin/bash", "-c"]
 # Install SGX
 
-ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.13.3/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.13.103.1.bin
-RUN curl -o sgx.bin "${SGX_URL}" \
+ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.15/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.15.100.3.bin
+RUN  curl -o sgx.bin "${SGX_URL}" \
   && chmod +x ./sgx.bin \
   && ./sgx.bin --prefix=/opt/intel \
-  && rm ./sgx.bin \
-  && echo '. /opt/intel/sgxsdk/environment' >> /root/.bashrc
+  && rm ./sgx.bin
+
+# Github actions overwrites the runtime home directory, so we need to install in a global directory.
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+RUN  mkdir -p ${RUSTUP_HOME} \
+  && mkdir -p ${CARGO_HOME}
 
 # Install rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2020-07-01
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2021-07-21
 
 ENV SGX_SDK=/opt/intel/sgxsdk
-ENV PATH=/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/intel/sgxsdk/bin:/opt/intel/sgxsdk/bin/x64
+ENV PATH=/opt/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/intel/sgxsdk/bin:/opt/intel/sgxsdk/bin/x64
 ENV PKG_CONFIG_PATH=/opt/intel/sgxsdk/pkgconfig
 ENV LD_LIBRARY_PATH=/opt/intel/sgxsdk/sdk_libs
-
-# Add additonal toolchains
-RUN rustup toolchain install nightly-2021-03-25
-RUN rustup toolchain install nightly-2021-07-21


### PR DESCRIPTION
Add os dependencies for MC and move rust/cargo homes so we can use this image in GHA

- update OS release
- libpq-dev (postgresql)
- update sgx sdk
- move cargo home to support GHA.  Github uses a different home dir.
- set default rust to current nightly.