### PR TITLE
Add `libsqlite3-dev` to `rust-sgx-base`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
      libclang-dev \
      libprotobuf-dev \
      libpq-dev \
+     libsqlite3-dev \
      libssl1.1 \
      libssl-dev \
      llvm \


### PR DESCRIPTION
https://github.com/mobilecoinfoundation/mobilecoin/pull/2157 revealed that we now require libsqlite3, probably since https://github.com/mobilecoinfoundation/mobilecoin/pull/2066