### PR TITLE
Tweak builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,11 +76,9 @@ RUN apt-get update \
   && rm -r /var/lib/apt/lists
 
 # Setup postgresql for local testing
-RUN sed -i \
-  -e 's|host    all             all             127.0.0.1/32            md5|host    all             all             127.0.0.1/32            trust|'\
-  -e 's|host    all             all             ::1/128                 md5|host    all             all             ::1/128                 trust|' \
-  /etc/postgresql/*/main/pg_hba.conf
-RUN service postgresql start && su postgres -c "createuser --superuser root"
+RUN sed -i -e '/127.0.0.1|::1/ s/md5/trust/g' /etc/postgresql/*/main/pg_hba.conf && \
+  service postgresql start && \
+  su postgres -c "createuser --superuser root"
 
 # Install test helpers from released binaries.
 # TODO: Remove cargo2junit and other unused helpers when we migrate off of CircleCI.


### PR DESCRIPTION
* Move `SHELL` to the top of each stage
* Simplify postgres initialization
* Make `cbindgen` executable