### PR TITLE
Add `killall` command to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN curl -LsSf https://deb.nodesource.com/setup_18.x | bash -s \
     postgresql-client \
     python3 \
     python3-pip \
+    psmisc \
   && apt-get clean \
   && rm -r /var/lib/apt/lists
 


### PR DESCRIPTION
Previously `killall` was not available in the image.  Now the `psmisc`
package is installed to provide the `killall` command.