### PR TITLE
This reverts PR #13 and puts us back on SGX 2.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
   && rm -r /var/lib/apt/lists
 
 # Install SGX
-ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.17.100.3.bin
+ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.16/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin
 RUN  curl -o sgx.bin "${SGX_URL}" \
   && chmod +x ./sgx.bin \
   && ./sgx.bin --prefix=/opt/intel \


### PR DESCRIPTION
This is a bit funky but doing this allows us to get test coverage
on the go-grpc-gateway in master, without also bumping SGX to 2.17.

We can revert this and so increase to SGX 2.17 change at a later
time when we are ready to do that.

In the meantime, it's bad for the docker image to keep progressing
in versions without any of them being tested in CI.