### PR TITLE
Add entrypoint to make mob prompt local user aware.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN GO_PKG=go1.18.5.linux-amd64.tar.gz \
 
 ENV GOPATH=/opt/go/
 ENV PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
+RUN mkdir -p "${GOPATH}"
 
 # Add sources for nodejs and install it and other helpers from apt.
 RUN curl -LsSf https://deb.nodesource.com/setup_18.x | bash -s \
@@ -85,6 +86,7 @@ RUN curl -LsSf https://deb.nodesource.com/setup_18.x | bash -s \
     python3 \
     python3-pip \
     psmisc \
+    sudo \
   && apt-get clean \
   && rm -r /var/lib/apt/lists
 
@@ -95,9 +97,13 @@ RUN sed -Ei -e '/127.0.0.1|::1/ s/md5/trust/g' /etc/postgresql/*/main/pg_hba.con
 
 # Install test helpers from released binaries.
 RUN curl -LsSf https://get.nexte.st/latest/linux \
-    | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin \
+    | tar zxf - -C ${CARGO_HOME}/bin \
   && curl -LsSf https://github.com/eqrion/cbindgen/releases/download/v0.24.2/cbindgen \
-    -o ${CARGO_HOME:-~/.cargo}/bin/cbindgen \
+    -o ${CARGO_HOME}/bin/cbindgen \
   && curl -LsSf https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz \
-    | tar xzf - -C ${CARGO_HOME:-~/.cargo}/bin --strip-components=1 sccache-v0.3.0-x86_64-unknown-linux-musl/sccache \
-  && chmod 0755 ${CARGO_HOME:-~/.cargo}/bin/{cbindgen,sccache}
+    | tar xzf - -C ${CARGO_HOME}/bin --strip-components=1 sccache-v0.3.0-x86_64-unknown-linux-musl/sccache \
+  && chmod 0755 ${CARGO_HOME}/bin/{cbindgen,sccache}
+
+COPY entrypoint-builder-install.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/entrypoint-builder-install.sh
+++ b/entrypoint-builder-install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Entrypoint for builder-install/mob prompt container.
+#   Set up user and set permissions
+
+set -e
+
+echo "Executing $0"
+
+is_set()
+{
+    var_name="${1}"
+    if [ -z "${!var_name}" ]
+    then
+        echo "${var_name} is not set."
+        exit 1
+    fi
+}
+
+if [[ -n "${EXTERNAL_UID}" ]]
+then
+    echo "Found User ID ${EXTERNAL_UID}, setting up and switching to that user."
+
+    is_set EXTERNAL_USER
+    is_set EXTERNAL_GID
+    is_set EXTERNAL_GROUP
+
+    # Add group
+    groupadd -g "${EXTERNAL_GID}" "${EXTERNAL_GROUP}"
+
+    # create the user
+    useradd -m -o \
+        -u "${EXTERNAL_UID}" \
+        -g "${EXTERNAL_GID}" \
+        -s "/bin/bash" \
+        "${EXTERNAL_USER}"
+
+    mkdir -p .mob
+    # Copy CARGO_HOME if it doesn't exist in the working dir
+    if [[ ! -d ".mob/cargo" ]]
+    then
+        cp -r "${CARGO_HOME}" .mob/cargo
+    fi
+
+    CARGO_HOME=$(pwd)/.mob/cargo
+
+    # Set up user .bashrc
+    root_env=$(env)
+    env_skips=("HOSTNAME" "PWD" "HOME" "LS_COLORS" "LESSCLOSE" "LESSOPEN" "SHLVL" "_")
+
+    for pair in ${root_env}
+    do
+        # split pair into p array
+        IFS='='; read -ra p <<< "${pair}"; unset IFS
+
+        # skip setting user envs, we just want to pass on mob stuff
+        for skip in "${env_skips[@]}"
+        do
+            if [[ "${p[0]}" == "${skip}" ]]
+            then
+                continue 2
+            fi
+        done
+
+        # add export to user .bashrc
+        echo "export ${p[0]}=${p[1]}" >> "/home/${EXTERNAL_USER}/.bashrc"
+    done
+
+    # set up no password sudo access
+    echo "${EXTERNAL_USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/user
+    chmod 440 /etc/sudoers.d/user
+
+    # set permissions for build tools.
+    chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" ".mob"
+    chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${GOPATH}"
+
+    # now change to external user
+    sudo -u "${EXTERNAL_USER}" -H /bin/bash -c "cd /tmp/mobilenode; exec $*"
+else
+    # or no user provided and we just exec.
+    exec "$@"
+fi


### PR DESCRIPTION
Add entrypoint script to `builder-installer` container that will setup a matching user/group in the `mob prompt` container. This should keep the files created in the mob prompt matching the local user.

Associated mobilecoin PR: https://github.com/mobilecoinfoundation/mobilecoin/pull/2504

- Add sudo for switching users
- Remove some CARGO_HOME variable defaults that will never be used.
- Add entrypoint script
  - If `EXTERNAL_UID` is set, then create a user/group in the container that matches the local user.
  - Add a `.mob` directory to preserve the sccache and cargo package cache between `mob prompt` runs
  - Copy `CARGO_HOME` data to `.mob` so pre-installed cargo packages can be utilized.
  - Setup bashrc for the new user to preserve mob/builder vars.
  - fix permissions on dirs used for building code.
  - setup sudoers so new user can switch up to root if necessary.

This should not affect how the CI/CD scripts run. 