### PR TITLE
Mob prompt improvements

### DIFF
--- a/entrypoint-builder-install.sh
+++ b/entrypoint-builder-install.sh
@@ -107,7 +107,7 @@ then
     chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${GOPATH}"
 
     # (mob) will mount your .ssh keys into the container at /var/tmp/user/.ssh by default.
-    # We can directly mount to /home or useradd won't setup the home directory.
+    # We can't directly mount to /home, or useradd won't setup the home directory.
     # link ssh dir to user home if available
     if [[ -d "/var/tmp/user/.ssh" ]]
     then


### PR DESCRIPTION
Some improvements for mob prompt tool.

- Allow override of repo path, but set `/tmp/mobilenode` as the default.
- use REPO_PATH and not assume we are in a place where the mobilecoin repo has been shared.
- Fix ssh-agent sharing for MacOS.
- Link existing .ssh to user home if shared with the container.