### PR TITLE
chore: add license and copyrights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Copyright (c) 2022 MobileCoin Inc.
-
 FROM ubuntu:focal-20221019 as rust-sgx-base
 
 SHELL ["/bin/bash", "-c"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 MobileCoin Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/entrypoint-builder-install.sh
+++ b/entrypoint-builder-install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2022 MobileCoin Inc.
 
 # Entrypoint for builder-install/mob prompt container.
 # Comments marked with (mob) are functionality integrated with the mobilecoinfoundation/mobilecoin "mob" tool.


### PR DESCRIPTION
This repo contains the docker image that's used in `mob prompt` and our build/ci pipelines.  Since we refer to it in our build instructions, we should probably make this repo public.

- Adding copyright headers and MIT license.