### PR TITLE
Fix rustup perms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 MobileCoin Inc.
-FROM ubuntu:focal-20221019 as rust-sgx-base
+FROM ubuntu:focal-20230126 as rust-sgx-base
 
 SHELL ["/bin/bash", "-c"]
 
@@ -56,8 +56,10 @@ RUN  mkdir -p ${RUSTUP_HOME} \
 
 # Install rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- -y --default-toolchain nightly-2022-04-29
+  sh -s -- -y --default-toolchain nightly-2023-01-04
 
+# Install other toolchains
+RUN rustup toolchain install nightly-2022-04-29
 
 # Set up the builder-install image with more test helpers for CI.
 FROM rust-sgx-base AS builder-install

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,6 @@ RUN  mkdir -p ${RUSTUP_HOME} \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
   sh -s -- -y --default-toolchain nightly-2023-01-04
 
-# Install other toolchains
-RUN rustup toolchain install nightly-2022-04-29
-
 # Set up the builder-install image with more test helpers for CI.
 FROM rust-sgx-base AS builder-install
 

--- a/entrypoint-builder-install.sh
+++ b/entrypoint-builder-install.sh
@@ -109,7 +109,14 @@ then
     chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${GOPATH}"
 
     # (mob) fix permissions so rustup can be run by the user
-    chmod "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}"
+    chown "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}"
+    chown "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}/settings.toml"
+    chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}/tmp"
+    chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}/downloads"
+    chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}/update-hashes"
+    # just change the directory so we can add new toolchains
+    # recusrsive on this dir takes a looong time.
+    chown "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}/toolchains"
 
     # (mob) will mount your .ssh keys into the container at /var/tmp/user/.ssh by default.
     # We can't directly mount to /home, or useradd won't setup the home directory.

--- a/entrypoint-builder-install.sh
+++ b/entrypoint-builder-install.sh
@@ -105,7 +105,11 @@ then
     chmod 440 /etc/sudoers.d/user
 
     echo_err "-- Set permissions for build tools."
+    # (mob) fix permissions for gopath
     chown -R "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${GOPATH}"
+
+    # (mob) fix permissions so rustup can be run by the user
+    chmod "${EXTERNAL_USER}:${EXTERNAL_GROUP}" "${RUSTUP_HOME}"
 
     # (mob) will mount your .ssh keys into the container at /var/tmp/user/.ssh by default.
     # We can't directly mount to /home, or useradd won't setup the home directory.


### PR DESCRIPTION
### Motivation

Fix permissions in mob prompt so user can add additional rust toolchains.

- bump ubuntu 20.04 version
- change default rust toolchain to nightly-2023-01-04
- fix permissions so rustup can be run by the user