### PR TITLE
add libdbus-1-dev for ledger ble comms on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
      libssl-dev \
      libudev-dev \
      libusb-1.0-0-dev \
+     libdbus-1-dev \
      llvm \
      llvm-dev \
      pkg-config \


### PR DESCRIPTION
towards merging hardware wallet support (current [failure](https://github.com/mobilecoinofficial/full-service/actions/runs/6345401603/job/17237303390?pr=834#step:11:851)). we could turn off BLE support as we're not using it at the moment but, seems like we might as well add this now to solve the problem.

cc. @briancorbin 