### PR TITLE
Add rust-base target -- an image sans SGX SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ We recommend referencing the image by the hash instead of a tag to verify a cons
 The following command will build and tag `rust-sgx-base:latest`. (But not push it to dockerhub, the tag will be local to your machine.)
 
 ```
-docker build -t mobilecoin/rust-sgx-base .
+docker build -t mobilecoin/rust-sgx-base --target rust-sgx-base .
 ```
 
 This variation will build and tag `builder-install:latest`.
 
 ```
 docker build -t mobilecoin/builder-install .
+```
+
+A third variation is available, `rust-base`, which does not include the SGX SDKs. This facilitates building blockchain clients on non-intel architectures, e.g. linux/arm64.
+
+```
+docker build -t mobilecoin/rust-base --target rust-base .
 ```
 
 To help iterate on a `builder-install` image, you can test it by opening a prompt


### PR DESCRIPTION
## Motivation

`docker-rust-sgx-base` provides a consistent build environment for building MobileCoin services, components, enclaves, clients, etc. However, because of the SGX dependency, it can not be used on non-intel platforms.

This PR does a minor re-order of some of the `Dockerfile` steps so that one can now target a `rust-base` image which is the same as the `rust-sgx-base` variant except for leaving out the SGX specific SDKs, allowing it to be used to build client code, non-SGX services, and many MobileCoin libraries on platforms without i86 compatibility, such as arm64.

## Changes
* add rust-base target
* reorder steps to install rust toolchain prior to SGX SDKs
* create `BUILDER_INSTALL_BASE` `--build_arg` with default of `rust_sgx_base` to allow the `builder-install` target image to be able to be created for non-intel platforms.

## Todo
* Wire up ci to create rust-base images for amd64 and arm64, and push them up to dockerhub