### PR TITLE
add devcontainer build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,6 +122,34 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  docker-fat-sgx-devcontainer:
+    needs:
+    - docker-fat-sgx-builder
+    runs-on: mco-dev-small-x64
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Short Sha
+      id: short_sha
+      uses: mobilecoinofficial/gh-actions/short-sha@v0
+
+    - name: Docker fat-sgx-devcontainer
+      uses: mobilecoinofficial/gh-actions/docker@v0
+      with:
+        dockerfile: Dockerfile.devcontainer
+        flavor: latest=${{ env.PUSH_LATEST }}
+        images: mobilecoin/fat-sgx-devcontainer
+        build_args: |
+          BASE_IMAGE=fat-sgx-builder
+          BASE_IMAGE_TAG=${{ steps.short_sha.outputs.short_sha }}
+        tags: |
+          type=semver,pattern=v{{version}}
+          type=sha
+        push: true
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
   docker-fat-builder:
     needs:
     - docker-rust-base-merge
@@ -169,10 +197,57 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  success:
+  docker-fat-devcontainer:
     needs:
     - docker-fat-builder-merge
-    - docker-fat-sgx-builder
+    strategy:
+      matrix:
+        runner:
+        - mco-dev-small-x64
+        - mco-dev-small-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Short Sha
+      id: short_sha
+      uses: mobilecoinofficial/gh-actions/short-sha@v0
+
+    - name: Docker fat-builder
+      id: build
+      uses: mobilecoinofficial/gh-actions/docker@v0
+      with:
+        dockerfile: Dockerfile.devcontainer
+        images: mobilecoin/fat-devcontainer
+        build_args: |
+          BASE_IMAGE=fat-builder
+          BASE_IMAGE_TAG=${{ steps.short_sha.outputs.short_sha }}
+        outputs: type=image,name=mobilecoin/fat-devcontainer,push-by-digest=true,name-canonical=true,push=true
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        save_digest: true
+
+  docker-fat-devcontainer-merge:
+    runs-on: mco-dev-small-x64
+    needs:
+    - docker-fat-devcontainer
+    steps:
+    - name: Merge and Tag Digests
+      uses: mobilecoinofficial/gh-actions/docker-merge-digests@v0
+      with:
+        images: mobilecoin/fat-devcontainer
+        flavor: latest=${{ env.PUSH_LATEST }}
+        tags: |
+          type=semver,pattern=v{{version}}
+          type=sha
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  success:
+    needs:
+    - docker-fat-devcontainer-merge
+    - docker-fat-sgx-devcontainer
     runs-on: mco-dev-small-x64
     steps:
     - name: Success

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 to 2024 MobileCoin Inc.
 # hadolint global ignore=DL3008, DL3015, DL3007
 
-# Update fat-builder for use as a devcontainer
+# Update fat-devcontainer for use as a devcontainer
 
 # Set BASE_IMAGE as fat-builder or fat-sgx-builder image and Name/Tag the image
 # "FROM mobilecoin/fat-builder:latest" as mobilecoin/fat-devcontainer:latest

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 to 2024 MobileCoin Inc.
+# hadolint global ignore=DL3008, DL3015, DL3007
+
+# Update fat-builder for use as a devcontainer
+
+# Set BASE_IMAGE as fat-builder or fat-sgx-builder image and Name/Tag the image
+# "FROM mobilecoin/fat-builder:latest" as mobilecoin/fat-devcontainer:latest
+# "FROM mobilecoin/fat-sgx-build:latest" as mobilecoin/fat-sgx-devcontainer:latest
+
+ARG BASE_IMAGE=fat-builder
+ARG BASE_IMAGE_TAG=latest
+FROM mobilecoin/${BASE_IMAGE}:${BASE_IMAGE_TAG} AS base
+ARG TARGETARCH
+
+ARG USERNAME=sentz
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid "${USER_GID}" "${USERNAME}" \
+    && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}" -s /bin/bash \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > "/etc/sudoers.d/${USERNAME}" \
+    && chmod 0440 "/etc/sudoers.d/${USERNAME}" \
+    && chown -R sentz:sentz /opt
+
+COPY startup-devcontainer.sh /usr/local/bin/startup-devcontainer.sh
+
+# This squashes the image - why this kludge of a solution docker ???
+# a plain --squash flag wasn't good enough
+FROM scratch AS final
+
+COPY --from=base / /
+
+# If you squash this way we loose all the env vars from the base image
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV GOPATH=/opt/go/
+ENV PATH="/opt/cargo/bin:/usr/local/go/bin:${GOPATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/intel/sgxsdk/bin:/opt/intel/sgxsdk/bin/x64"
+ENV SGX_SDK=/opt/intel/sgxsdk
+ENV PKG_CONFIG_PATH=/opt/intel/sgxsdk/pkgconfig
+ENV LD_LIBRARY_PATH=/opt/intel/sgxsdk/sdk_libs

--- a/Dockerfile.fat-builder
+++ b/Dockerfile.fat-builder
@@ -4,8 +4,8 @@
 # Fat builder image for building and local testing of MobileCoin services.
 
 # Set BASE_IMAGE the rust-base or rust-sgx image and Name/Tag the image
-# "FROM mobilecoin/rust-base:latest" as mobilecoin/rust-builder:latest
-# "FROM mobilecoin/rust-sgx:latest" as mobilecoin/rust-sgx-builder:latest
+# "FROM mobilecoin/rust-base:latest" as mobilecoin/fat-builder:latest
+# "FROM mobilecoin/rust-sgx:latest" as mobilecoin/fat-sgx-builder:latest
 
 ARG BASE_IMAGE=rust-base
 ARG BASE_IMAGE_TAG=latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,30 @@ docker build -f ./Dockerfile.rust-base -t mobilecoin/rust-base:latest .
 
 1. Build `rust-base` image with the `latest` tag.
 2. Build `rust-sgx` image with the `latest` tag.
-2. Build `fat-sgx-builder` image
+3. Build `fat-sgx-builder` image
     ```
     docker build --build-arg BASE_IMAGE=rust-sgx -f ./Dockerfile.fat-builder -t mobilecoin/fat-sgx-builder:latest .
+    ```
+
+### mobilecoin/fat-devcontainer (amd64/arm64)
+
+`fat-devcontainer` is based off the `fat-builder` image, but includes a non-root user configuration for use as a [devcontainer](https://containers.dev/) with IDEs like VScode. Build this image off the `devcontainer` docker file using `fat-builder` as the `FROM` image.
+
+1. Build `rust-base` image with the `latest` tag.
+2. Build `fat-builder` image with the `latest` tag.
+3. Build `fat-devcontainer` image
+    ```
+    docker build --build-arg BASE_IMAGE=fat-builder -f ./Dockerfile.devcontainer -t mobilecoin/fat-devcontainer:latest .
+    ```
+
+### mobilecoin/fat-sgx-devcontainer (amd64)
+
+`fat-devcontainer` is based off the `fat-sgx-builder` image, but includes a non-root user configuration for use as a [devcontainer](https://containers.dev/) with IDEs like VScode. Build this image off the `devcontainer` docker file using `fat-sgx-builder` as the `FROM` image. This image includes SGX libraries or tools.
+
+1. Build `rust-base` image with the `latest` tag.
+2. Build `rust-sgx` image with the `latest` tag.
+3. Build `fat-sgx-builder` image with the `latest` tag.
+4. Build `fat-sgx-devcontainer` image
+    ```
+    docker build --build-arg BASE_IMAGE=fat-sgx-builder -f ./Dockerfile.devcontainer -t mobilecoin/fat-sgx-devcontainer:latest .
     ```

--- a/entrypoint-builder-install.sh
+++ b/entrypoint-builder-install.sh
@@ -6,20 +6,10 @@
 
 set -e
 
-is_set()
-{
-    var_name="${1}"
-    if [ -z "${!var_name}" ]
-    then
-        echo "${var_name} is not set."
-        exit 1
-    fi
-}
-
 # Echo to stderr - print details when verbose is set.
 echo_err()
 {
-    if [ -n "${ENTRYPOINT_VERBOSE}" ]
+    if [[ -n "${ENTRYPOINT_VERBOSE}" ]]
     then
         printf "%s\n" "$*" >&2
     fi
@@ -32,9 +22,10 @@ if [[ -n "${EXTERNAL_UID}" ]]
 then
     echo_err "-- Found User ID ${EXTERNAL_UID}, setting up and switching to that user."
 
-    is_set EXTERNAL_USER
-    is_set EXTERNAL_GID
-    is_set EXTERNAL_GROUP
+    # Check to make sure variables are set
+    : "${EXTERNAL_USER:?}"
+    : "${EXTERNAL_GID:?}"
+    : "${EXTERNAL_GROUP:?}"
 
     # (mob) uses /tmp/mobilenode to mount the mobilecoin repo. Allow override of repo path.
     REPO_PATH="${REPO_PATH:-/tmp/mobilenode}"

--- a/startup-devcontainer.sh
+++ b/startup-devcontainer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+opt_owner=$(stat -c %U /opt)
+
+if [[ "${opt_owner}" != "sentz" ]]
+then
+    echo "Changing /opt owner to sentz...(this may take a while)"
+    sudo chown -R sentz:sentz /opt
+fi


### PR DESCRIPTION
Extend fat-builder image to `fat-devcontainer` images for use with [devcontainers](https://containers.dev/) - containerized development environments integrated into IDEs like VSCode. 

- build fat-devcontainer and fat-sgx-devcontainer off of fat-builder images. 
- Add a default non-root user
- chown tools in /opt as this default user. 
